### PR TITLE
Bower update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,43 @@
-language: node_js
-sudo: required
-node_js: stable
-addons:
-  firefox: latest
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
-before_script:
-  - npm install web-component-tester
-  - npm install bower
-  - export PATH=$PWD/node_modules/.bin:$PATH
-  - bower install
-script:
-  - xvfb-run wct
-  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'default'; fi
+# Create .netrc for private repo install
+before_install:
+- echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
+# Branch whitelist
+branches:
+  only:
+    - master
 dist: trusty
+language: node_js
+node_js:
+  - "6"
+# Cache bower dependencies for faster/network error-tolerant builds (provided cache invalidation occurs as expected)
+cache:
+  directories:
+  - bower_components # bower packages
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+  slack:
+    template:
+      - "%{result}: %{repository} <%{build_url}|#%{build_number}>  (<%{compare_url}|%{commit}>)"
+      - "\tin %{duration} for %{author}'s commit:"
+      - "\t\"%{commit_subject}\""
+    rooms:
+      - ldschurch:S4NvL7BI3BFGOMfoiSCfARk5#treeweb-tw1-builds
+    on_pull_requests: false
+    on_success: always
+    on_failure: change
+    on_start: never
+addons:
+  sauce_connect: true
+before_script:
+- npm install -g bower web-component-tester
+# pipe bower install output through tee to create a log to parse for errors and preserve exit code
+- bower install --force-latest 2>&1 | tee bower-debug.log; ( exit ${PIPESTATUS[0]} )
+script:
+# pipe wct output through tee to create a log to parse for errors and preserve exit code
+- xvfb-run wct --skip-plugin local 2>&1 | tee wct.log; ( exit ${PIPESTATUS[0]} )
+after_success:
+- bin/tag_build.sh
+after_failure:
+- bin/report_failure_details.sh

--- a/bin/report_failure_details.sh
+++ b/bin/report_failure_details.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+set -o errexit
+set -o pipefail
+
+# Bash Script: report_failure_details.sh
+# Purpose: To report the failure details of a build directly to Slack.
+# Requirements: Add this script in travis.yml after_failure to add failure detail Slack notifications.
+
+# Only alert failure details on commits to master
+if [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+  COLOR="#ce0814"
+  BUILD_URL="https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
+  STATUS_TITLE="$TRAVIS_REPO_SLUG <$BUILD_URL|$TRAVIS_BUILD_NUMBER> failure details:"
+  STATUS_TITLE_FALLBACK="$TRAVIS_REPO_SLUG $TRAVIS_BUILD_NUMBER failure:"
+  STATUS_MESSAGE=""
+
+  # If a -debug error logfile is present and non-empty, parse for error and add to message
+
+  # Check for npm errors
+  if [ -s "npm-debug.log" ]; then
+    STATUS_MESSAGE+="NPM ERROR\n"
+    STATUS_MESSAGE+="$(sed -n -e "/error code/,\$p" npm-debug.log)"
+  fi
+
+  # Check for bower errors
+  if [ -s "bower-debug.log" ]; then
+    STATUS_MESSAGE+="BOWER ERROR\n"
+    STATUS_MESSAGE+="$(sed -n -e "/error details/,\$p" bower-debug.log)"
+  fi
+
+  # Check for unit test errors
+  if [ -s "wct.log" ]; then
+    STATUS_MESSAGE+="UNIT TEST ERROR\n"
+    STATUS_MESSAGE+="$(sed -n -e "/✖/,\$p" wct.log)"
+  fi
+
+  # If at least one of the failure logs was not empty, send the error details to Slack
+  if [[ ! -z "$STATUS_MESSAGE" ]]; then
+    STATUS_MESSAGE="\`\`\`$STATUS_MESSAGE\`\`\`"
+
+    echo -e "$STATUS_TITLE"
+    echo -e "$STATUS_MESSAGE"
+    #Teflon Slack notification (uses https://ldschurch.slack.com/services/122760792000)
+    curl -X POST --data-urlencode 'payload={ "username": "TravisBot", "text": "'"$STATUS_TITLE"'", "mrkdwn": true, "attachments": [{ "fallback": "'"$STATUS_TITLE_FALLBACK"'", "color": "'"$COLOR"'", "mrkdwn_in": ["text"], "text": "'"$STATUS_MESSAGE"'" }]}' https://hooks.slack.com/services/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
+  fi
+fi

--- a/bin/tag_build.sh
+++ b/bin/tag_build.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+set -o errexit
+set -o pipefail
+
+# Bash Script: tag_build.sh
+# Purpose: To tag a successful build and create a semver tag any time the bower version is updated.
+# Requirements: Add this script in travis.yml after_success to add the build number and semver tags in GitHub.
+
+# Only create new build tags on commits to master
+if [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+  git fetch
+  git reset --hard "$TRAVIS_COMMIT"
+
+  BOWER_VERSION="$(cat bower.json \
+    | grep version \
+    | head -1 \
+    | awk -F: '{ print $2 }' \
+    | sed 's/[",]//g' \
+    | tr -d '[:space:]')"
+
+  # If there is no tag/release for the current bower version, create one
+  if [ -z "$(git tag -l "$BOWER_VERSION")" ]; then
+
+    git tag -a "$BOWER_VERSION" -m "Travis CI auto bower version update" -m "$(git log --format=%B -n 1 "$TRAVIS_COMMIT")" "$TRAVIS_COMMIT"
+
+    echo -e "created semver tag: $BOWER_VERSION"
+  fi
+
+  git push origin --tags
+
+  # TODO: Webhook/integration to automatically consume the new component version by either pushing an empty commit to https://github.com/fs-webdev/component-catalog or forcing a Heroku rebuild (https://github.com/heroku/legacy-cli/issues/514#issuecomment-237604006)
+fi

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-i18n",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],
@@ -15,18 +15,22 @@
   "main": "wc-i18n.html",
   "license": "MIT",
   "homepage": "https://github.com/jshcrowthe/wc-i18n/",
-  "ignore": [
-    "/.*",
-    "/tests/"
-  ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.0",
-    "fetch": "^1.0.0",
-    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
-    "fetch-mock": "https://unpkg.com/fetch-mock@5.5.0/es5/client-browserified.js"
+    "es6-promise": "git+https://github.com/stefanpenner/es6-promise.git#~4.1.0",
+    "fetch": "git+https://github.com/github/fetch#~2.0.3",
+    "fetch-mock": "https://unpkg.com/fetch-mock@5.10.0/es5/client-browserified.js",
+    "polymer": "git+https://github.com/Polymer/polymer#~1.9.1"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "Polymer/web-component-tester#4.3.4"
-  }
+    "iron-component-page": "git+https://github.com/PolymerElements/iron-component-page#~1.1.9",
+    "web-component-tester": "git+https://github.com/Polymer/web-component-tester#~5.0.1"
+  },
+  "ignore": [
+    ".*",
+    "bin/",
+    "bin/*",
+    "test/",
+    "test/*",
+    "wct.conf.json"
+  ]
 }

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
 </head>
 <body>
   <script>

--- a/test/wc-i18n-default-test.html
+++ b/test/wc-i18n-default-test.html
@@ -15,10 +15,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
+    <script src="../../es6-promise/dist/es6-promise.auto.js"></script>
     <script src="../../fetch/fetch.js"></script>
     <script src="../../fetch-mock/index.js"></script>
-    
+
     <script>
       // This is a nasty global test hack. Super bad but it works
       var srcLocales = {

--- a/test/wc-i18n-test.html
+++ b/test/wc-i18n-test.html
@@ -15,10 +15,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
+    <script src="../../es6-promise/dist/es6-promise.auto.js"></script>
     <script src="../../fetch/fetch.js"></script>
     <script src="../../fetch-mock/index.js"></script>
-    
+
     <script>
       // This is a nasty global test hack. Super bad but it works
       var srcLocales = {

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,20 @@
+{
+  "plugins": {
+    "local": {
+      "browsers": [ "chrome" ]
+    },
+    "sauce": {
+      "browsers": [
+        {
+          "browserName":  "safari",
+          "platform":     "OS X 10.11",
+          "version":      "10"
+        },
+        {
+          "browserName":  "firefox",
+          "platform":     "Linux"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Alphabetize dependencies.
Update dependencies & pin to minor revision.
Use full dependency URL.
Remove resolutions.
Limit local unit tests to Chrome.

Update to node 6.
Add auto-release tagging.

Release 2.1.1.