### PR TITLE
Build-related updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,9 @@
+**/.*
 **/*bower_components*/**
 **/*min.*
 **/*node_modules*/**
 **/*polyfill*
+**/coverage/**
 **/demo/**
 **/reports/**
 **/test/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,16 @@
 module.exports = {
   extends: [
-    'frontier',
-    'tree'
+    'eslint-config-frontier',
+    'eslint-config-tree',
   ],
   plugins: [
     // Enable plugins that are not natively supported by Code Climate. Otherwise results in build errors.
+    'eslint-plugin-bestpractices',
     'eslint-plugin-deprecate',
-    'eslint-plugin-sonarjs'
-  ],
+    'eslint-plugin-no-only-tests',
+    'eslint-plugin-no-skip-tests',
+    'eslint-plugin-promise',
+    'eslint-plugin-sonarjs',
+    'eslint-plugin-test-selectors' // NOTE: Only runs against JSX
+  ]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Bug reports are primarily handled through [JIRA](https://almtools.ldschurch.org/
 
 ### Contributing Pull Requests
 
-- Follow ESLint/CSSLint best practices. Enforced by Code Climate, `semistandard`, and `stylelint`.
+- Follow ESLint/CSSLint best practices. Enforced by Code Climate, `eslint`, and `stylelint`.
 - Increment bower.json version (used to automatically tag a new release).
 - **Include tests that test the range of behavior that changes with your PR.** If your PR fixes a bug, make sure your tests capture that bug. If your PR adds new behavior, make sure that behavior is fully tested. Every PR must include associated tests (unit, component, acceptance) as appropriate.
 - Update any associated documentation affected by your change.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,20 @@
-addons:
-  sauce_connect: true
-# Branch whitelist
-branches:
-  only:
-    - master
-# Caching of bower_components & node_modules disabled, due to an increase in delayed breakages
-cache:
-  npm: false
-  directories: null
-dist: trusty
-language: node_js
-node_js:
-  - 10
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-  slack:
-    # Custom template used because SUCCESS/FAILURE is all the way at the end by default
-    template:
-      - '%{result}: %{repository} <%{build_url}|#%{build_number}>  (<%{compare_url}|%{commit}>)'
-      - "\tin %{duration} for %{author}'s commit:"
-      - "\t\"%{commit_subject}\""
-    rooms:
-      - 'familysearch:S4NvL7BI3BFGOMfoiSCfARk5#treeweb-gold-builds'
-    on_pull_requests: false
-    on_success: always
-    on_failure: change
-    on_start: never
+version: ~> 1.0
 
-before_install:
-  # Create .netrc for private repo install
-  - 'echo -e "machine github.com\n  login $GITHUB_AUTH_TOKEN" >> ~/.netrc'
-  - npm install -g bower
-install:
-  # pipe bower install output through tee to create a log to parse for errors and preserve exit code
-  - 'bower install --config.interactive=false 2>&1 | tee bower-debug.log; ( exit ${PIPESTATUS[0]} )'
-  - npm install
-before_script:
-  - node_modules/fs-common-build-scripts/bin/before_script.sh
-script:
-  # Run linting checks, suppressing warnings for cleanliness
-  - npx eslint '**/*.html' '**/*.json' --quiet
-  - stylelint '**/*.html' '**/*.css'
-  # Run tests
-  - 'npx wct --configFile wct.conf.windows.json --skip-plugin local && npx wct --configFile wct.conf.json --skip-plugin local'
-after_success:
-  - node node_modules/fs-common-build-scripts/bin/create_release.js
-after_failure:
-  - node_modules/fs-common-build-scripts/bin/report_failure_details.sh
-after_script:
-  - node_modules/fs-common-build-scripts/bin/after_script.sh
+# This Travis CI configuration makes use of imports (https://docs.travis-ci.com/user/build-config-imports/) to commonize and simplify build configuration. Utilizes shallow merge, allowing overwrites for most root level sections, and deep merge for notifications.
+import:
+  - source: fs-webdev/fs-common-build-scripts:travis/base.yml@v2
+    mode: merge
+  - source: fs-webdev/fs-common-build-scripts:travis/sauce.yml@v2
+    mode: merge
+  - source: fs-webdev/fs-common-build-scripts:travis/notifications.yml@v2
+    mode: deep_merge
+  - source: fs-webdev/fs-common-build-scripts:travis/notifications/tw-gold.yml@v2
+    mode: deep_merge
+  - source: fs-webdev/fs-common-build-scripts:travis/before.yml@v2
+    mode: merge
+  - source: fs-webdev/fs-common-build-scripts:travis/install_with_bower.yml@v2
+    mode: deep_merge_prepend
+  - source: fs-webdev/fs-common-build-scripts:travis/scripts.yml@v2
+    mode: merge
+
+# Put anything additional you wish to have happen before running tests in an `install` section.

--- a/README.md
+++ b/README.md
@@ -175,11 +175,13 @@ window.WCI18n.setLanguage('ko'); //- Sets language to 'ko'
 
 ## Running the Component
 
+<details>
+
 1. (Once) Install or update the [Polymer CLI](https://www.npmjs.com/package/polymer-cli): ```npm i -g polymer-cli```
 1. (Once) Install the [frontier-cli](https://github.com/fs-webdev/frontier-cli): ```npm i -g https://github.com/fs-webdev/frontier-cli```
-1. Run `bower install` to load all of the dependencies.
+1. Run `npm install` to get dependencies needed to set up the unit testing framework, useful commit hooks, and standards tools (`bower install` is also run as a post-install step).
+1. Or (if you want to live dangerously) just run `bower install` to load all of the component's primary dependencies.
 1. Run `polymer analyze > analysis.json` to initialize the docs page.
-1. Run `npm install` if you plan on contributing to install development plugins. See [Development Standards Enforcement](#development-standards-enforcement)
 
 This component's auto-generated documentation is viewable by running:
 
@@ -195,102 +197,42 @@ frontier element serve -d
 
 This component's demo page is viewable by running the above command.
 
+</details>
+
 ## Online Docs & Demo
 
-The FamilySearch Element Catalog is located at: [https://www.familysearch.org/frontier/elements/](https://www.familysearch.org/frontier/elements/), with access granted to members of the `fs-webdev` GitHub organization. You can browse through each shared element's docs and demo
+The FamilySearch Element Catalog is located at: [https://www.familysearch.org/frontier/catalog/](https://www.familysearch.org/frontier/catalog/), with access granted to members of the `fs-webdev` GitHub organization. [How to create a shared component of your own](https://www.familysearch.org/frontier/ui-components/creating-a-new-web-component/).
 
-## Submodules for Common Files
+## Build, Commit, Test, and Standards Tools
 
-The `tree-common-build-scripts` folder is a Git submodule, made to house build-related code common across multiple repositories. In order to update, run:
+For detail about automatic releases, test plugins, pre-commit hooks, and standards enforcement, see: [fs-common-build-scripts](https://github.com/fs-webdev/fs-common-build-scripts#)
 
-```bash
-git pull --recurse-submodules; git submodule update --remote --recursive
-```
-
-## Automatic Releases
-
-Releases are automatically be created after successful builds of `master` when bower/package.json versions change by manually calling the [Frontier Github Automator](https://github.com/fs-webdev/github-automator) via the shared [create_release.js](https://github.com/fs-webdev/tree-common-build-scripts/blob/master/bin/create_release.js) node script.
-
-## Special Plugins
-
-In order for the **`size-limit`** WCT plugin to run, you need to globally install it:
-
-```bash
-npm install -g fs-webdev/size-limit
-```
-
-### Development Standards Enforcement
-
-> FamilySearch components are developed in compliance with ESLint and CSSLint common standards. Standards checking is run as part of an npm-based husky pre-push hook, and can also be explicitly run via the **`npm test`**, **`npm run standard`**, and **`npm run-standard-fix`** commands. Currently needs an **`npm install`** before everything will work.
->
-> EXPLANATION: The **pre-push** hook will run standards with autofix enabled, and if there are no errors, append any associated changes made to the current commit. This means that if you have any local uncommitted changes, they will be automatically included in any commit. Prior to committing, revert local changes. TODO: Try to use the stashandappend npm script in concert with a prepush
-
-In order for **`semistandard`** to run, you need to globally install it:
-
-```bash
-npm install -g semistandard
-npm install -g eslint-plugin-html
-npm install -g snazzy
-```
-
-which will enable the node scripts to run:
-
-```bash
-semistandard --verbose '**/*.html' '**/*.js' --fix | snazzy
-```
-
-for a report of JS standards infractions and to automatically fix the easy infractions _(mostly whitespace, commas, quotes, and semicolons)_. Customizations should be added to a `semistandard` section of package.json.
-
-In order for **`stylelint`** to run, you need to globally install it:
-
-```bash
-npm install -g stylelint
-npm install -g stylelint-config-standard
-```
-
-which will enable the node scripts to run:
-
-```bash
-stylelint '**/*.html' '**/*.css' --fix
-```
-
-for a report of CSS standards infractions and to automatically fix the easy infractions _(mostly whitespace)_. Customizations should be added to a `stylelint` section of package.json.
-
-> NOTE: You can run `standard` functionally on a repo with the module just globally installed, but `stylelint 8.4.0` currently needs a local npm install in the target repository, otherwise it can't find its dependencies correctly.
+> IMPORTANT NOTE: When running package dependency commands (i.e. `wct`), you need to prefix the command with [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
 ## Running Tests
 
+<details>
+
 This component is set up to be tested via [web-component-tester](https://github.com/Polymer/web-component-tester).
 
-In order to run the `wct` command, you need to globally install web-component-tester:
-
-> NOTE OF WARNING: This component is using a [patcharound](https://github.com/thedeeno/web-component-tester-istanbul/issues/38#issuecomment-287544522) in order to incorporate code coverage reporting. In order to be able to run unit tests locally, (as of 2017-05-18) you must install the *patched* versions of web-component-tester and web-component-tester-istanbul. (You may need to uninstall other versions, first)
-
-```bash
-npm install -g t2ym/web-component-tester#6.0.0-wct6-plugin.1
-npm install -g t2ym/web-component-tester-istanbul#0.10.1-wct6.11
-```
-
-To run tests locally, run:
+To run tests locally (skipping sauce), run:
 
 ```bash
 npm test
 ```
 
-which will run the standards checks through `semistandard` and `stylelint`, and then the unit tests via `wct`.
+which will run unit tests locally via `wct`.
 
-> NOTE: Do not run the `npm test` command on Travis CI, unless you want to run semistandard & stylelint, which would require them to be globally installed, first.
-
-or
+To run against sauce (skipping local), run:
 
 ```bash
-wct --skip-plugin sauce
+npm run test:ci
 ```
 
 If you need to debug locally (keeping the browser open), run:
 
 ```bash
-wct --skip-plugin sauce -p
+npm run test:persistent
 ```
 
 or
@@ -302,5 +244,9 @@ polymer test --skip-plugin sauce --local chrome -p
 If you want to run the full suite of SauceLabs browser tests, run:
 
 ```bash
-wct test/index.html --configFile wct.conf.json  --sauce-username {USERNAME} --sauce-access-key {ACCESS_KEY}
+npx wct test/index.html --configFile wct.conf.json  --sauce-username {USERNAME} --sauce-access-key {ACCESS_KEY}
 ```
+
+> NOTE: You can export `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` in your `.bash_profile` to be able to simply run `npx wct` without needing additional options.
+
+</details>

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
   },
   "homepage": "https://github.com/fs-webdev/wc-i18n#readme",
   "devDependencies": {
-    "eslint-config-frontier": "github:fs-webdev/eslint-config-frontier",
-    "eslint-config-tree": "github:fs-webdev/eslint-config-tree#semver:^1",
-    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^1",
-    "husky": "^2"
+    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^2"
   },
   "husky": {
     "hooks": {
@@ -40,12 +37,11 @@
     "postinstall": "bower install",
     "lint": "eslint '**/*.html' '**/*.json' && stylelint '**/*.html' '**/*.css'",
     "lint:fix": "eslint '**/*.html' '**/*.json' --fix && stylelint '**/*.html' '**/*.css' --fix",
-    "lint:staged": "node node_modules/fs-common-build-scripts/bin/pre_commit_checks.js && lint-staged",
-    "standard": "npm run lint",
-    "standard-fix": "npm run lint:fix",
+    "lint:quiet": "eslint '**/*.html' '**/*.json' --quiet && stylelint '**/*.html' '**/*.css' --quiet",
+    "lint:staged": "lint-staged && node node_modules/fs-common-build-scripts/bin/pre_commit_checks.js",
     "test": "wct --skip-plugin sauce",
-    "test-p": "wct --skip-plugin sauce -p",
-    "test-s": "wct --configFile wct.conf.windows.json --skip-plugin local && wct --configFile wct.conf.json --skip-plugin local"
+    "test:ci": "wct --configFile wct.conf.windows.json --skip-plugin local && wct --configFile wct.conf.json --skip-plugin local",
+    "test:persistent": "wct --skip-plugin sauce -p"
   },
   "stylelint": {
     "about": "https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md#possible-errors",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -39,7 +39,7 @@
       ],
       "thresholds": {
         "global": {
-          "statements": 85,
+          "statements": 90,
           "branches": 75,
           "functions": 80,
           "lines": 85
@@ -48,8 +48,8 @@
     },
     "size-limit": {
       "path": "wc-i18n.html",
-      "limitNoPolymer": "2 KB",
-      "limitNoExternals": "2 KB"
+      "limitNoPolymer": "5 KB",
+      "limitNoExternals": "5 KB"
     }
   }
 }


### PR DESCRIPTION
Utilize fs-common-build-scripts#2 shared import files for common Travis CI configuration.
Enable additional helpful ESLint plugins.
Remove redundant devDependencies.
Remove semistandard references and commands.
Clean up .dotfile configurations.
Add uniform `lint:quiet` and `test:ci` commands (required by common configuration script: scripts.yml).